### PR TITLE
Rename VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ phpunit.xml
 wsl-init.log
 .backup/*
 .DS_Store
+/code

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -16,7 +16,7 @@ class Homestead
     end
 
     # Configure The Box
-    config.vm.define settings['name'] ||= 'homestead'
+    config.vm.define settings['name'] ||= 'svpernova09-homestead'
     config.vm.box = settings['box'] ||= 'Svpernova09/homestead'
     unless settings.has_key?('SpeakFriendAndEnter')
       config.vm.box_version = settings['version'] ||= '>= 14.0.3, < 15.0.0'


### PR DESCRIPTION
Renamed VM from `homestead` to `svpernova09-homestead` to prevent name collision with `laravel/homestead` installs.