### PR TITLE
Fix apt error during provisioning due to Label change of ondreij's PHP repo

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -270,7 +270,7 @@ class Homestead
         end
       end
 
-      config.vm.provision "apt_update", type: "shell", inline: "apt-get update"
+      config.vm.provision "apt_update", type: "shell", inline: "apt-get --allow-releaseinfo-change update"
 
       # Ensure we have PHP versions used in sites in our features
       if settings.has_key?('sites')


### PR DESCRIPTION
Currently, provisioning of the VM fails due to the label change in the ondreij/php repo:

```
homestead: E: Repository 'https://ppa.launchpadcontent.net/ondrej/php/ubuntu jammy InRelease' changed its 'Label' value from '***** The main PPA for supported PHP versions with many PECL extensions *****' to 'PPA for PHP'
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```
This is already described in #20. This PR implements the fix stated there.