### PR TITLE
Revert mjs file for symfony4.sh

### DIFF
--- a/scripts/site-types/symfony4.sh
+++ b/scripts/site-types/symfony4.sh
@@ -45,10 +45,6 @@ block="server {
 
     index index.html index.htm index.php;
 
-    types {
-        application/javascript mjs;
-    }
-
     charset utf-8;
     client_max_body_size 100M;
 


### PR DESCRIPTION
So sorry.... the type directive doesn't add the new .mjs type, but replaces all defined mime types....

The type `application/javascript mjs` must be added in /etc/nginx/mime.types, but I don't know if this file is managed by homestead.